### PR TITLE
Add screen zoom feature for accessibility

### DIFF
--- a/dist/Cores/ericlewis.LunarLander/interact.json
+++ b/dist/Cores/ericlewis.LunarLander/interact.json
@@ -1,7 +1,23 @@
 {
     "interact": {
         "magic": "APF_VER_1",
-        "variables": [],
+        "variables": [
+            {
+                "id": 0,
+                "name": "Screen Zoom",
+                "type": "list",
+                "enabled": true,
+                "persist": true,
+                "address": "0x50000000",
+                "defaultval": "0x00",
+                "mask": "0x03",
+                "options": [
+                    {"value": "0x00", "name": "Off"},
+                    {"value": "0x01", "name": "Small"},
+                    {"value": "0x02", "name": "Large"}
+                ]
+            }
+        ],
         "messages": []
     }
 }

--- a/src/fpga/core/core_top.sv
+++ b/src/fpga/core/core_top.sv
@@ -309,6 +309,18 @@ assign vpll_feed = 1'bZ;
 // for bridge write data, we just broadcast it to all bus devices
 // for bridge read data, we have to mux it
 // add your own devices here
+
+// Interact variables
+reg [31:0] interact_zoom = 32'h0;
+
+always @(posedge clk_74a) begin
+    if (bridge_wr) begin
+        casex (bridge_addr)
+            32'h50000000: interact_zoom <= bridge_wr_data;
+        endcase
+    end
+end
+
 always @(*) begin
     casex(bridge_addr)
     default: begin
@@ -318,6 +330,9 @@ always @(*) begin
         // example
         // bridge_rd_data <= example_device_data;
         bridge_rd_data <= 0;
+    end
+    32'h50000000: begin
+        bridge_rd_data <= interact_zoom;
     end
     32'hF8xxxxxx: begin
         bridge_rd_data <= cmd_bridge_rd_data;
@@ -766,7 +781,8 @@ LLANDER_TOP LLANDER_TOP
 	.VID_HBLANK(hblank),
 	.VID_VBLANK(vblank_lunarlander),
 	.DIP(m_dip),
-	.RESET_L (reset_n),	
+	.ZOOM(interact_zoom[1:0]),
+	.RESET_L (reset_n),
 	.clk_6(clk_6),
 	.clk_25(clk_25)
 );

--- a/src/fpga/core/rtl/llander_top.vhd
+++ b/src/fpga/core/rtl/llander_top.vhd
@@ -99,6 +99,8 @@ entity LLANDER_TOP is
 
     DIP               : in    std_logic_vector(7 downto 0);
 
+    ZOOM              : in    std_logic_vector(1 downto 0);
+
     RESET_L           : in    std_logic;
 
     -- ref clock in
@@ -197,6 +199,8 @@ begin
 
       BEAM_ON     => beam_on,
       BEAM_ENA    => beam_ena,
+
+      ZOOM        => ZOOM,
 
       VIDEO_R_OUT => VIDEO_R_OUT,
       VIDEO_G_OUT => VIDEO_G_OUT,


### PR DESCRIPTION
Implements a screen zoom setting accessible from the Analogue Pocket
interact menu, addressing the request for larger display output to
improve readability. The zoom works by remapping framebuffer read
addresses to display a cropped/enlarged portion of the 512x512
framebuffer:

- Off: Normal 1:1 display (default)
- Small: ~1.14x zoom (reads 448px from center, offset 32)
- Large: ~1.33x zoom (reads 384px from center, offset 64)

The setting persists across sessions via the APF interact system.

Closes #1

https://claude.ai/code/session_01NYKHEx1oSSxcWrEi23wb4L

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core video address generation and adds a new bridge-mapped register; risk is mainly visual correctness/regressions (blanking/edges) rather than security or data integrity.
> 
> **Overview**
> Adds a new persistent APF Interact variable, **Screen Zoom**, exposed as an `Off/Small/Large` list mapped to `0x50000000`.
> 
> Wires this setting through the bridge bus (`core_top.sv`) into the video pipeline by adding a `ZOOM` input to `LLANDER_TOP`/`ASTEROIDS_DW`, where zoom is implemented by remapping framebuffer read addresses to crop and enlarge the displayed region.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbcd79812eadcf349df83953cf1a89a20597ec6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->